### PR TITLE
fix: implement only analyzing the title of the data

### DIFF
--- a/routes/inserting.js
+++ b/routes/inserting.js
@@ -13,15 +13,15 @@ const preprocessDatas = async (datas) => {
   var preprocessedDatas = [];
   for (let data of datas) {
     // 한글 제외하고 모조리 제거
-    if (!/^[^\u0000-\u007F]*$/.test(data.contentText)) {
-      editedData = data.contentText.replace(
+    if (!/^[^\u0000-\u007F]*$/.test(data.title)) {
+      editedData = data.title.replace(
         /[^\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7FF\uFF00-\uFFEF]/g,
         " "
       );
     }
 
-    // 형태소 분석
-    var morphemes = await ExecuteMorphModulePromise(editedData);
+    // **제목만** 형태소 분석 및 키워드 추출
+    var morphemes = await ExecuteMorphModulePromise(data.title);
 
     // 키워드 추출
     var keywords = [];


### PR DESCRIPTION
GCP 배포 서버의 메모리(RAM) 용량이 적어서 형태소 분석 및 키워드 추출 시 메모리 용량 초과 문제가 발생함. 따라서 배포 버전에서는 데이터의 본문이 아니라 제목에서만 형태소 분석 및 키워드 추출하도록 수정함.